### PR TITLE
Made Job list context menu column map to Completed status so it can be filtered

### DIFF
--- a/DerailValleyPlanner/Pages/Job/Index.razor
+++ b/DerailValleyPlanner/Pages/Job/Index.razor
@@ -16,7 +16,7 @@
 }
 else
 {
-    <MudSwitch @bind-Checked="@_showComplete">Show Complete Jobs</MudSwitch>
+    @* <MudSwitch @bind-Checked="@_showComplete">Show Complete Jobs</MudSwitch> *@
     <MudDataGrid
         Filterable="true"
         Items="@_jobs"
@@ -46,7 +46,7 @@ else
             <PropertyColumn Property="j => '$' + j.Pays.ToString()" Title="Pays"/>
             <PropertyColumn Property="j => j.Description" Title="Description"/>
             <PropertyColumn Property="j => j.MassPerWagon.ToString() + 't'" Title="Mass Per Wagon"/>
-            <TemplateColumn CellClass="d-flex justify-end" Sortable="false" Filterable="false">
+            <PropertyColumn Property="j => j.Complete" Title="" CellClass="d-flex justify-end" Sortable="true" Filterable="true">
                 <CellTemplate>
                     <MudMenu Icon="fad fa-ellipsis-vertical" AnchorOrigin="Origin.BottomLeft" TransformOrigin="Origin.TopLeft">
                         <MudMenuItem OnClick="() => GoToEditPage(context)" Icon="fas fa-pencil" IconSize="Size.Small">Edit</MudMenuItem>
@@ -54,7 +54,7 @@ else
                         <MudMenuItem OnClick="() => DeleteJob(context)" Icon="fad fa-trash" IconSize="Size.Small" Disabled="@(context.Item.Stops?.Any() == true)">Delete</MudMenuItem>
                     </MudMenu>
                 </CellTemplate>
-            </TemplateColumn>
+            </PropertyColumn>
         </Columns>
     </MudDataGrid>
 }

--- a/DerailValleyPlanner/Pages/Job/Index.razor
+++ b/DerailValleyPlanner/Pages/Job/Index.razor
@@ -46,7 +46,7 @@ else
             <PropertyColumn Property="j => '$' + j.Pays.ToString()" Title="Pays"/>
             <PropertyColumn Property="j => j.Description" Title="Description"/>
             <PropertyColumn Property="j => j.MassPerWagon.ToString() + 't'" Title="Mass Per Wagon"/>
-            <PropertyColumn Property="j => j.Complete" Title="" CellClass="d-flex justify-end" Sortable="true" Filterable="true">
+            <PropertyColumn Property="j => j.Complete" Title="Completed" CellClass="d-flex justify-end" Sortable="true" Filterable="true">
                 <CellTemplate>
                     <MudMenu Icon="fad fa-ellipsis-vertical" AnchorOrigin="Origin.BottomLeft" TransformOrigin="Origin.TopLeft">
                         <MudMenuItem OnClick="() => GoToEditPage(context)" Icon="fas fa-pencil" IconSize="Size.Small">Edit</MudMenuItem>


### PR DESCRIPTION
Closes #18

Usage:
1. Click the filter icon on the far right column
2. On the far left, a window will pop out
3. Select the right dropdown and select "true"
4. Now it will only show incomplete Jobs.